### PR TITLE
Fix incorrect regex in FormatNumber.Locales.fromString

### DIFF
--- a/src/FormatNumber/Locales.elm
+++ b/src/FormatNumber/Locales.elm
@@ -96,7 +96,7 @@ to a `Locale`, it will return the `base` locale**.
     fromString "-3,141.593"
     --> { base
     --> | decimals = Exact 3
-    --> , thousandSeparator = "
+    --> , thousandSeparator = ","
     --> , decimalSeparator = "."
     --> , negativePrefix = "-"
     --> }
@@ -107,7 +107,7 @@ fromString value =
     let
         regex : Regex.Regex
         regex =
-            "\\D"
+            "\\d"
                 |> Regex.fromString
                 |> Maybe.withDefault Regex.never
 

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -1,4 +1,4 @@
 {
   "root": "../src",
-  "tests": [ "FormatNumber", "./README.md" ]
+  "tests": [ "FormatNumber", "FormatNumber.Locales", "./README.md" ]
 }


### PR DESCRIPTION
The regex is supposed to extract all non-digit characters from the string, but its usage with Regex.replace
actually led to it extracting all digits - this broke the rest of the parsing function and resulted in
an incorrect locale.

In addition, the FormatNumber.Locales module wasn't being verified by the tests, so this error was missed.