### PR TITLE
Adding support to Indian Numbering system

### DIFF
--- a/src/FormatNumber.elm
+++ b/src/FormatNumber.elm
@@ -28,33 +28,33 @@ import FormatNumber.Stringfy exposing (stringfy)
 
 {-| Format a float number as a pretty string:
 
-    import FormatNumber.Locales exposing (Decimals(..), Locale, frenchLocale, spanishLocale, usLocale)
+    import FormatNumber.Locales exposing (Decimals(..), NumericSystem(..), Locale, frenchLocale, spanishLocale, usLocale)
 
-    format { decimals = Exact 2, thousandSeparator = ".", decimalSeparator = ",", negativePrefix = "−", negativeSuffix = "", positivePrefix = "", positiveSuffix = "", zeroPrefix = "", zeroSuffix = "" } 123456.789
+    format { decimals = Exact 2, thousandSeparator = ".", decimalSeparator = ",", negativePrefix = "−", negativeSuffix = "", positivePrefix = "", positiveSuffix = "", zeroPrefix = "", zeroSuffix = "", numericSystem = Western } 123456.789
     --> "123.456,79"
 
-    format { decimals = Exact 2, thousandSeparator = ",", decimalSeparator = ".", negativePrefix = "−", negativeSuffix = "", positivePrefix = "", positiveSuffix = "", zeroPrefix = "", zeroSuffix = "" } 1234.5567
+    format { decimals = Exact 2, thousandSeparator = ",", decimalSeparator = ".", negativePrefix = "−", negativeSuffix = "", positivePrefix = "", positiveSuffix = "", zeroPrefix = "", zeroSuffix = "", numericSystem = Western } 1234.5567
     --> "1,234.56"
 
-    format (Locale (Exact 3) "." "," "−" "" "" "" "" "") -7654.3210
+    format (Locale (Exact 3) "." "," "−" "" "" "" "" "" Western) -7654.3210
     --> "−7.654,321"
 
-    format (Locale (Exact 1) "," "." "−" "" "" "" "" "") -0.01
+    format (Locale (Exact 1) "," "." "−" "" "" "" "" "" Western) -0.01
     --> "0.0"
 
-    format (Locale (Exact 2) "," "." "−" "" "" "" "" "") 0.01
+    format (Locale (Exact 2) "," "." "−" "" "" "" "" "" Western) 0.01
     --> "0.01"
 
-    format (Locale (Exact 0) "," "." "−" "" "" "" "" "") 123.456
+    format (Locale (Exact 0) "," "." "−" "" "" "" "" "" Western) 123.456
     --> "123"
 
-    format (Locale (Exact 0) "," "." "−" "" "" "" "" "") 1e9
+    format (Locale (Exact 0) "," "." "−" "" "" "" "" "" Western) 1e9
     --> "1,000,000,000"
 
-    format (Locale (Exact 5) "," "." "−" "" "" "" "" "") 1.0
+    format (Locale (Exact 5) "," "." "−" "" "" "" "" "" Western) 1.0
     --> "1.00000"
 
-    format (Locale (Exact 2) "," "." "(" ")" "" "" "" "") -1.0
+    format (Locale (Exact 2) "," "." "(" ")" "" "" "" "" Western) -1.0
     --> "(1.00)"
 
     format usLocale pi
@@ -105,35 +105,41 @@ import FormatNumber.Stringfy exposing (stringfy)
     format usLocale 7.34767309e-22
     --> "0.00"
 
-    format (Locale (Exact 3) "." "," "−" "" "" "" "" "") 123
+    format (Locale (Exact 3) "." "," "−" "" "" "" "" "" Western) 123
     --> "123,000"
 
-    format (Locale (Min 3) "." "," "−" "" "" "" "" "") 123.45678
+    format (Locale (Min 3) "." "," "−" "" "" "" "" "" Western) 123.45678
     --> "123,45678"
 
-    format (Locale (Min 0) "." "," "−" "" "" "" "" "") 1230
+    format (Locale (Min 0) "." "," "−" "" "" "" "" "" Western) 1230
     --> "1.230"
 
-    format (Locale (Min 3) "." "," "−" "" "" "" "" "") 123.45600
+    format (Locale (Min 3) "." "," "−" "" "" "" "" "" Western) 123.45600
     --> "123,456"
 
-    format (Locale (Min 3) "." "," "−" "" "" "" "" "") 123.456001
+    format (Locale (Min 3) "." "," "−" "" "" "" "" "" Western) 123.456001
     --> "123,456001"
 
-    format (Locale (Max 3) "." "," "−" "" "" "" "" "") 123.45678
+    format (Locale (Max 3) "." "," "−" "" "" "" "" "" Western) 123.45678
     --> "123,457"
 
-    format (Locale (Max 3) "." "," "−" "" "" "" "" "") 123.45633
+    format (Locale (Max 3) "." "," "−" "" "" "" "" "" Western) 123.45633
     --> "123,456"
 
-    format (Locale (Max 3) "." "," "−" "" "" "" "" "") 123.45600
+    format (Locale (Max 3) "." "," "−" "" "" "" "" "" Western) 123.45600
     --> "123,456"
 
-    format (Locale (Max 3) "." "," "−" "" "" "" "" "") 123.45
+    format (Locale (Max 3) "." "," "−" "" "" "" "" "" Western) 123.45
     --> "123,45"
 
-    format (Locale (Max 3) "." "," "−" "" "" "" "" "") 123
+    format (Locale (Max 3) "." "," "−" "" "" "" "" "" Western) 123
     --> "123"
+
+    format { usLocale | numericSystem = Indian } 7.34767309e22
+    --> "73,47,67,30,90,00,00,00,00,00,000.00"
+
+    format { usLocale | numericSystem = Indian } 75
+    --> "75.00"
 
 -}
 format : Locales.Locale -> Float -> String

--- a/src/FormatNumber/Locales.elm
+++ b/src/FormatNumber/Locales.elm
@@ -1,6 +1,7 @@
 module FormatNumber.Locales exposing
     ( Decimals(..)
     , Locale
+    , NumericSystem(..)
     , base
     , fromString
     , frenchLocale, spanishLocale, usLocale
@@ -44,6 +45,18 @@ type Decimals
     | Max Int
     | Exact Int
 
+{-| The 'NumericSystem' type contains different numeric systems currently 
+supported:
+
+  - Western - It separates digits by 1000s. 1000000 -> 1,000,000
+  - Indian - It separates digits by 1000 then it is separated by 100s. 
+    1000000 -> 10,00,000
+
+-}
+type NumericSystem
+    = Western
+    | Indian
+
 
 {-| This is the `Locale` type and constructor.
 -}
@@ -57,6 +70,7 @@ type alias Locale =
     , positiveSuffix : String
     , zeroPrefix : String
     , zeroSuffix : String
+    , numericSystem : NumericSystem
     }
 
 
@@ -83,6 +97,7 @@ base =
     , positiveSuffix = ""
     , zeroPrefix = ""
     , zeroSuffix = ""
+    , numericSystem = Western
     }
 
 

--- a/src/FormatNumber/Locales.elm
+++ b/src/FormatNumber/Locales.elm
@@ -45,7 +45,7 @@ type Decimals
     | Max Int
     | Exact Int
 
-{-| The 'NumericSystem' type contains different numeric systems currently 
+{-| The `NumericSystem` type contains different numeric systems currently
 supported:
 
   - `Western` separates digits by thousands (e.g.: 1000000 might be separated

--- a/src/FormatNumber/Locales.elm
+++ b/src/FormatNumber/Locales.elm
@@ -48,9 +48,10 @@ type Decimals
 {-| The 'NumericSystem' type contains different numeric systems currently 
 supported:
 
-  - Western - It separates digits by 1000s. 1000000 -> 1,000,000
-  - Indian - It separates digits by 1000 then it is separated by 100s. 
-    1000000 -> 10,00,000
+  - `Western` separates digits by thousands (e.g.: 1000000 might be separated
+    as 1,000,000).
+  - `Indian` separates digits by the thousand and, from there, by hundreds
+    (e.g.: 1000000 might be separated as 10,00,000).
 
 -}
 type NumericSystem

--- a/src/FormatNumber/Parser.elm
+++ b/src/FormatNumber/Parser.elm
@@ -106,14 +106,15 @@ splitThousands integers =
         |> reversedSplitThousands
         |> List.reverse
 
-{-| Split a `String` in `List String` grouping by digits as per Indian 
-numbering system. Last 3 digits are grouped together but after that 
-numbers are grouped in two. 
-[Indian numbering system](https://en.wikipedia.org/wiki/Indian_numbering_system#Use_of_separators):
+{-| Splits `String` into `List String` grouping by digits as `Indian`. Last 3
+digits are grouped together but after that numbers are grouped in pairs. For
+more details:
+[Indian numbering system](https://en.wikipedia.org/wiki/Indian_numbering_system#Use_of_separators).
 
     splitByIndian "12345678" --> [ "1", "23", "45", "678" ]
 
     splitByIndian "12" --> [ "12" ]
+
 
 -}
 splitByIndian : String -> List String

--- a/src/FormatNumber/Parser.elm
+++ b/src/FormatNumber/Parser.elm
@@ -117,7 +117,6 @@ more details:
 
     splitByIndian "12" --> [ "12" ]
 
-
 -}
 splitByIndian : String -> List String
 splitByIndian integers =
@@ -251,7 +250,7 @@ getDecimals locale digits =
         Min min ->
             addZerosToFit min digits
 
-{-| Given a 'NumericSystem` parses a integer `String` into 
+{-| Given a 'NumericSystem` parses an integer `String` into
 a `List String` representing grouped integers:
 
     import FormatNumber.Locales exposing (NumericSystem(..))
@@ -261,7 +260,6 @@ a `List String` representing grouped integers:
     splitIntegers Indian "1000000" --> ["10", "00", "000"]
 
 -}
-
 splitIntegers : NumericSystem -> String -> List String
 splitIntegers numericSystem integers = 
     case numericSystem of

--- a/src/FormatNumber/Stringfy.elm
+++ b/src/FormatNumber/Stringfy.elm
@@ -6,43 +6,43 @@ import FormatNumber.Parser exposing (FormattedNumber)
 
 {-| Stringify a `FormattedNumber`:
 
-    import FormatNumber.Locales exposing (Locale, Decimals(..))
-    import Parser exposing (FormattedNumber)
+    import FormatNumber.Locales exposing (Locale, Decimals(..), NumericSystem(..))
+    import FormatNumber.Parser exposing (FormattedNumber)
 
-    stringfy (Locale (Exact 3) "." "," "−" "" "" "" "" "") (FormattedNumber 3.1415 ["3"] "142" "" "")
+    stringfy (Locale (Exact 3) "." "," "−" "" "" "" "" "" Western) (FormattedNumber 3.1415 ["3"] "142" "" "")
     --> "3,142"
 
-    stringfy (Locale (Exact 3) "." "," "−" "" "" "" "" "") (FormattedNumber -3.1415 ["3"] "142" "−" "")
+    stringfy (Locale (Exact 3) "." "," "−" "" "" "" "" "" Western) (FormattedNumber -3.1415 ["3"] "142" "−" "")
     --> "−3,142"
 
-    stringfy (Locale (Exact 0) "." "," "−" "" "" "" "" "") (FormattedNumber 1234567.89 ["1", "234", "568"] "" "" "")
+    stringfy (Locale (Exact 0) "." "," "−" "" "" "" "" "" Western) (FormattedNumber 1234567.89 ["1", "234", "568"] "" "" "")
     --> "1.234.568"
 
-    stringfy (Locale (Exact 0) "." "," "−" "" "" "" "" "") (FormattedNumber 1234567.89 ["1", "234", "568"] "" "−" "")
+    stringfy (Locale (Exact 0) "." "," "−" "" "" "" "" "" Western) (FormattedNumber 1234567.89 ["1", "234", "568"] "" "−" "")
     --> "−1.234.568"
 
-    stringfy (Locale (Exact 1) "." "," "−" "" "+" "" "" "") (FormattedNumber 999.9 ["999"] "9" "+" "")
+    stringfy (Locale (Exact 1) "." "," "−" "" "+" "" "" "" Western) (FormattedNumber 999.9 ["999"] "9" "+" "")
     --> "+999,9"
 
-    stringfy (Locale (Exact 1) "." "," "−" "" "" "+" "" "") (FormattedNumber 999.9 ["999"] "9" "" "+")
+    stringfy (Locale (Exact 1) "." "," "−" "" "" "+" "" "" Western) (FormattedNumber 999.9 ["999"] "9" "" "+")
     --> "999,9+"
 
-    stringfy (Locale (Exact 1) "." "," "−" "" "" "" "" "") (FormattedNumber 999.9 ["999"] "9" "−"  "")
+    stringfy (Locale (Exact 1) "." "," "−" "" "" "" "" "" Western) (FormattedNumber 999.9 ["999"] "9" "−"  "")
     --> "−999,9"
 
-    stringfy (Locale (Exact 1) "." "," "−" "" "" "" "" "") (FormattedNumber 999.9 ["999"] "9" "−" "")
+    stringfy (Locale (Exact 1) "." "," "−" "" "" "" "" "" Western) (FormattedNumber 999.9 ["999"] "9" "−" "")
     --> "−999,9"
 
-    stringfy (Locale (Exact 2) "." "," "−" "" "" "" "" "") (FormattedNumber 0.001 ["0"] "00" "" "")
+    stringfy (Locale (Exact 2) "." "," "−" "" "" "" "" "" Western) (FormattedNumber 0.001 ["0"] "00" "" "")
     --> "0,00"
 
-    stringfy (Locale (Exact 2) "." "," "−" "" "" "" "" "") (FormattedNumber 0.001 ["0"] "00" "" "")
+    stringfy (Locale (Exact 2) "." "," "−" "" "" "" "" "" Western) (FormattedNumber 0.001 ["0"] "00" "" "")
     --> "0,00"
 
-    stringfy (Locale (Exact 1) "." "," "−" "" "" "" "" "") (FormattedNumber 5497558138.88 ["5", "497", "558", "138"] "9" "" "")
+    stringfy (Locale (Exact 1) "." "," "−" "" "" "" "" "" Western) (FormattedNumber 5497558138.88 ["5", "497", "558", "138"] "9" "" "")
     --> "5.497.558.138,9"
 
-    stringfy (Locale (Exact 1) "." "," "−" "" "" "" "" "") (FormattedNumber 5497558138.88 ["5", "497", "558", "138"] "9" "−" "")
+    stringfy (Locale (Exact 1) "." "," "−" "" "" "" "" "" Western) (FormattedNumber 5497558138.88 ["5", "497", "558", "138"] "9" "−" "")
     --> "−5.497.558.138,9"
 
 -}


### PR DESCRIPTION
This is draft PR to fix #36. Changes in the code are captured below:

1. Added NumericSystem type to capture locale numeric type
2. Added numericSystem field to Locale to track the value
3. Added default numericSystem value to base Locale to preserve backward
   compatibility
4. Added functions to Parser to support splitting by Indian system
5. Updated parser function to support Indian numbering system

@cuducos I am assuming that most users of library use one of the locales such as base, usLocale etc. to build their locale rather than defining it from scratch. I am yet to update fromString function to get locale from browser. This PR is to enable you to review and advise me on my approach.